### PR TITLE
Add data-bind and conversion-partition parameters

### DIFF
--- a/biomero/slurm_client.py
+++ b/biomero/slurm_client.py
@@ -309,7 +309,9 @@ class SlurmClient(Connection):
                  enable_job_progress: bool = True,
                  enable_workflow_analytics: bool = True,
                  sqlalchemy_url: str = None,
-                 config_only: bool = False):
+                 config_only: bool = False,
+                 slurm_data_bind_path: str = None,
+                 slurm_conversion_partition: str = None):
         """
         Initializes a new instance of the SlurmClient class.
 
@@ -419,6 +421,8 @@ class SlurmClient(Connection):
         self.converter_images = converter_images
         self.slurm_model_jobs = slurm_model_jobs
         self.slurm_model_jobs_params = slurm_model_jobs_params
+        self.slurm_data_bind_path = slurm_data_bind_path
+        self.slurm_conversion_partition = slurm_conversion_partition
 
         # Init cache. Keep responses for 360 seconds
         self.cache = requests_cache.backends.sqlite.SQLiteCache(
@@ -810,6 +814,34 @@ class SlurmClient(Connection):
                     convert_cmds.append(
                         f"singularity build -F \"{convert_name}_latest.sif\" {convert_def} >> sing.log 2>&1 ; echo 'finished {convert_name}_latest.sif' &")
                 _ = self.run_commands(convert_cmds)
+            ## BUILD converter from singularity def file
+            # currently known converters
+            # 3a. ZARR to OME-TIFF
+            # TODO extract these values to e.g. config if we have more
+            convert_name = "convert_zarr_to_ometiff"
+            convert_py = f"{convert_name}.py"
+            convert_script_local = files("resources").joinpath(
+                convert_py)
+            convert_def = f"{convert_name}.def"
+            convert_def_local = files("resources").joinpath(
+                convert_def)
+            _ = self.put(local=convert_script_local,
+                        remote=self.slurm_converters_path)
+            _ = self.put(local=convert_def_local,
+                        remote=self.slurm_converters_path)
+            # Build singularity container from definition
+            with self.cd(self.slurm_converters_path):
+                convert_cmds = []
+                if self.slurm_images_path:
+                    # TODO Change the tmp dir?
+                    # export SINGULARITY_TMPDIR=~/my-scratch/tmp;
+                    # only if file does not exist yet
+                    # convert_cmds.append(f"[ ! -f {convert_name}.sif ]")
+                    # EDIT -- NO, then we can't update! Force rebuild!
+                    # download /build new container
+                    convert_cmds.append(
+                        f"singularity build -F \"{convert_name}_latest.sif\" {convert_def} >> sing.log 2>&1 ; echo 'finished {convert_name}_latest.sif' &")
+                _ = self.run_commands(convert_cmds)            
 
     def setup_job_scripts(self):
         """
@@ -908,6 +940,12 @@ class SlurmClient(Connection):
         slurm_converters_path = configs.get(
             "SLURM", "slurm_converters_path",
             fallback=cls._DEFAULT_SLURM_CONVERTERS_PATH)
+        slurm_data_bind_path = configs.get(
+            "SLURM", "slurm_data_bind_path",
+            fallback= None)
+        slurm_conversion_partition = configs.get(
+            "SLURM", "slurm_conversion_partition",
+            fallback= None)
 
         # Split the MODELS into paths, repos and images
         models_dict = dict(configs.items("MODELS"))
@@ -987,7 +1025,9 @@ class SlurmClient(Connection):
                    enable_job_progress=enable_job_progress,
                    enable_workflow_analytics=enable_workflow_analytics,
                    sqlalchemy_url=sqlalchemy_url,
-                   config_only=config_only)
+                   config_only=config_only,
+                   slurm_data_bind_path=slurm_data_bind_path,
+                   slurm_conversion_partition=slurm_conversion_partition)
 
     def cleanup_tmp_files(self,
                           slurm_job_id: str,
@@ -2022,8 +2062,10 @@ class SlurmClient(Connection):
             "IMAGE_PATH": f"\"{self.slurm_images_path}/{model_path}\"",
             "IMAGE_VERSION": f"{workflow_version}",
             "SINGULARITY_IMAGE": f"\"{image}_{workflow_version}.sif\"",
-            "SCRIPT_PATH": f"\"{self.slurm_script_path}\""
+            "SCRIPT_PATH": f"\"{self.slurm_script_path}\"",
         }
+        if self.slurm_data_bind_path is not None:
+            sbatch_env["APPTAINER_BINDPATH"] = f"\"{self.slurm_data_bind_path}\""
         workflow_env = self.workflow_params_to_envvars(**kwargs)
         env = {**sbatch_env, **workflow_env}
 
@@ -2083,8 +2125,12 @@ class SlurmClient(Connection):
             "CONVERSION_PATH": f"\"{self.slurm_converters_path}\"",
             "CONVERTER_IMAGE": chosen_converter,
             "SCRIPT_PATH": f"\"{self.slurm_script_path}\"",
-            "CONFIG_FILE": f"\"{config_file}\""
+            "CONFIG_FILE": f"\"{config_file}\"",
         }
+        if self.slurm_data_bind_path is not None:
+            sbatch_env["APPTAINER_BINDPATH"] = f"\"{self.slurm_data_bind_path}\""
+        if self.slurm_conversion_partition is not None:
+            sbatch_env["CONVERSION_PARTITION"] = f"\"{self.slurm_conversion_partition}\""
 
         conversion_cmd = "sbatch --job-name=conversion --export=ALL,CONFIG_PATH=\"$PWD/$CONFIG_FILE\" --array=1-$N \"$SCRIPT_PATH/convert_job_array.sh\""
         # conversion_cmd_waiting = "sbatch --job-name=conversion --export=ALL,CONFIG_PATH=\"$PWD/$CONFIG_FILE\" --array=1-$N --wait $SCRIPT_PATH/convert_job_array.sh"

--- a/biomero/slurm_client.py
+++ b/biomero/slurm_client.py
@@ -813,36 +813,7 @@ class SlurmClient(Connection):
                     # download /build new container
                     convert_cmds.append(
                         f"singularity build -F \"{convert_name}_latest.sif\" {convert_def} >> sing.log 2>&1 ; echo 'finished {convert_name}_latest.sif' &")
-                _ = self.run_commands(convert_cmds)
-            ## BUILD converter from singularity def file
-            # currently known converters
-            # 3a. ZARR to OME-TIFF
-            # TODO extract these values to e.g. config if we have more
-            convert_name = "convert_zarr_to_ometiff"
-            convert_py = f"{convert_name}.py"
-            convert_script_local = files("resources").joinpath(
-                convert_py)
-            convert_def = f"{convert_name}.def"
-            convert_def_local = files("resources").joinpath(
-                convert_def)
-            _ = self.put(local=convert_script_local,
-                        remote=self.slurm_converters_path)
-            _ = self.put(local=convert_def_local,
-                        remote=self.slurm_converters_path)
-            # Build singularity container from definition
-            with self.cd(self.slurm_converters_path):
-                convert_cmds = []
-                if self.slurm_images_path:
-                    # TODO Change the tmp dir?
-                    # export SINGULARITY_TMPDIR=~/my-scratch/tmp;
-                    # only if file does not exist yet
-                    # convert_cmds.append(f"[ ! -f {convert_name}.sif ]")
-                    # EDIT -- NO, then we can't update! Force rebuild!
-                    # download /build new container
-                    convert_cmds.append(
-                        f"singularity build -F \"{convert_name}_latest.sif\" {convert_def} >> sing.log 2>&1 ; echo 'finished {convert_name}_latest.sif' &")
-                _ = self.run_commands(convert_cmds)            
-
+                _ = self.run_commands(convert_cmds)        
     def setup_job_scripts(self):
         """
         Sets up job scripts for Slurm operations.

--- a/resources/slurm-config.ini
+++ b/resources/slurm-config.ini
@@ -35,6 +35,14 @@ slurm_converters_path=my-scratch/singularity_images/converters
 # Note: 
 # This example is relative to the Slurm user's home dir
 slurm_script_path=my-scratch/slurm-scripts
+# Path to bind a folder to slurm/singularity jobs, required when by default data folder is not bound to singularity container
+#
+# Note: 
+# This example is relative to the Slurm user's home dir
+slurm_data_bind_path=my-scratch/data
+# Set partition to run conversion jobs when no default partition is set on your HPC
+#
+slurm_conversion_partition=cpu-short
 # -------------------------------------
 # REPOSITORIES
 # -------------------------------------

--- a/tests/unit/test_slurm_client.py
+++ b/tests/unit/test_slurm_client.py
@@ -234,10 +234,21 @@ def test_copy_zip_locally(mock_get, mock_logger, slurm_client):
             Slurm to {local_tmp_storage}')
 
 
-@pytest.mark.parametrize("email, time_limit", [("", ""), ("user@example.com", "10:00:00")])
-def test_get_workflow_command(slurm_client,
-                              email,
-                              time_limit):
+@pytest.mark.parametrize(
+    "email, time_limit, data_bind_path, conversion_partition",
+    [
+        ("", "", None, None),  # Test without bind path and partition
+        (
+            "user@example.com",
+            "10:00:00",
+            "/bind/path",
+            "partition_name",
+        ),  # Test with bind path and partition
+    ],
+)
+def test_get_workflow_command(
+    slurm_client, email, time_limit, data_bind_path, conversion_partition
+):
     # GIVEN
     workflow = "example_workflow"
     workflow_version = "1.0"
@@ -246,15 +257,20 @@ def test_get_workflow_command(slurm_client,
     slurm_client.slurm_model_paths = {"example_workflow": "workflow_path"}
     slurm_client.slurm_model_jobs = {"example_workflow": "job_script.sh"}
     slurm_client.slurm_model_jobs_params = {
-        "example_workflow": [" --param3=value3", " --param4=value4"]}
+        "example_workflow": [" --param3=value3", " --param4=value4"]
+    }
     slurm_client.slurm_model_images = {"example_workflow": "user/image"}
     slurm_client.slurm_data_path = "/path/to/slurm_data"
     slurm_client.slurm_converters_path = "/path/to/slurm_converters"
     slurm_client.slurm_images_path = "/path/to/slurm_images"
     slurm_client.slurm_script_path = "/path/to/slurm_script"
+    slurm_client.slurm_data_bind_path = data_bind_path
+    slurm_client.slurm_conversion_partition = conversion_partition
 
-    expected_sbatch_cmd = f"sbatch --param3=value3 --param4=value4 --time={time_limit} --mail-user={email} --output=omero-%j.log \
-            \"{slurm_client.slurm_script_path}/job_script.sh\""
+    expected_sbatch_cmd = (
+        f'sbatch --param3=value3 --param4=value4 --time={time_limit} --mail-user={email} --output=omero-%j.log \
+            "{slurm_client.slurm_script_path}/job_script.sh"'
+    )
     expected_env = {
         "DATA_PATH": '"/path/to/slurm_data/input_data_folder"',
         "IMAGE_PATH": '"/path/to/slurm_images/workflow_path"',
@@ -262,17 +278,27 @@ def test_get_workflow_command(slurm_client,
         "SINGULARITY_IMAGE": '"image_1.0.sif"',
         "SCRIPT_PATH": '"/path/to/slurm_script"',
         "PARAM1": "value1",
-        "PARAM2": "value2"
+        "PARAM2": "value2",
     }
+
+    # Add expected environment variables for bind path and partition if set
+    if data_bind_path is not None:
+        expected_env["APPTAINER_BINDPATH"] = f'"{data_bind_path}"'
 
     # WHEN
     sbatch_cmd, env = slurm_client.get_workflow_command(
-        workflow, workflow_version, input_data, email, time_limit, param1="value1", param2="value2")
+        workflow,
+        workflow_version,
+        input_data,
+        email,
+        time_limit,
+        param1="value1",
+        param2="value2",
+    )
 
     # THEN
     assert sbatch_cmd == expected_sbatch_cmd
     assert env == expected_env
-
 
 @pytest.mark.parametrize("source_format, target_format", [("zarr", "tiff"), ("xyz", "abc")])
 @patch('biomero.slurm_client.SlurmClient.run_commands', new_callable=SerializableMagicMock)
@@ -324,36 +350,63 @@ def test_run_conversion_workflow_job(mock_result, mock_run_commands, slurm_clien
     assert slurm_job.job_state is None
     
     
-@pytest.mark.parametrize("source_format, target_format, version", [("zarr", "tiff", "1.0"), ("xyz", "abc", "v38.20-alpha.4")])
-@patch('biomero.slurm_client.SlurmClient.run_commands', new_callable=SerializableMagicMock)
-@patch('fabric.Result', new_callable=SerializableMagicMock)
-def test_run_conversion_workflow_job_versioned(mock_result, mock_run_commands, slurm_client, source_format, target_format, version):
+@pytest.mark.parametrize(
+    "source_format, target_format, data_bind_path, conversion_partition",
+    [
+        ("zarr", "tiff", None, None),  # Test without bind path and partition
+        (
+            "xyz",
+            "abc",
+            "/bind/path",
+            "partition_name",
+        ),  # Test with bind path and partition
+    ],
+)
+@patch(
+    "biomero.slurm_client.SlurmClient.run_commands", new_callable=SerializableMagicMock
+)
+@patch("fabric.Result", new_callable=SerializableMagicMock)
+def test_run_conversion_workflow_job(
+    mock_result,
+    mock_run_commands,
+    slurm_client,
+    source_format,
+    target_format,
+    data_bind_path,
+    conversion_partition,
+):
     # GIVEN
     folder_name = "example_folder"
 
     slurm_client.slurm_data_path = "/path/to/slurm_data"
     slurm_client.slurm_converters_path = "/path/to/slurm_converters"
     slurm_client.slurm_script_path = "/path/to/slurm_script"
-    slurm_client.converter_images = {'zarr_to_tiff': 'cellularimagingcf/convert_zarr_to_tiff:1.0', 
-                                     'xyz_to_abc': 'cellularimagingcf/convert_xyz_to_abc:v38.20-alpha.4'}
+    slurm_client.converter_images = None
+    slurm_client.slurm_data_bind_path = data_bind_path
+    slurm_client.slurm_conversion_partition = conversion_partition
 
     expected_config_file = f"config_{folder_name}.txt"
     expected_data_path = f"{slurm_client.slurm_data_path}/{folder_name}"
-    expected_conversion_cmd, expected_sbatch_env = (
-        "sbatch --job-name=conversion --export=ALL,CONFIG_PATH=\"$PWD/$CONFIG_FILE\" --array=1-$N \"$SCRIPT_PATH/convert_job_array.sh\"",
-        {
-            "DATA_PATH": f"\"{expected_data_path}\"",
-            "CONVERSION_PATH": f"\"{slurm_client.slurm_converters_path}\"",
-            "CONVERTER_IMAGE": f"convert_{source_format}_to_{target_format}_{version}.sif",
-            "SCRIPT_PATH": f"\"{slurm_client.slurm_script_path}\"",
-            "CONFIG_FILE": f"\"{expected_config_file}\""
-        }
-    )
+    expected_sbatch_env = {
+        "DATA_PATH": f'"{expected_data_path}"',
+        "CONVERSION_PATH": f'"{slurm_client.slurm_converters_path}"',
+        "CONVERTER_IMAGE": f"convert_{source_format}_to_{target_format}_latest.sif",
+        "SCRIPT_PATH": f'"{slurm_client.slurm_script_path}"',
+        "CONFIG_FILE": f'"{expected_config_file}"',
+    }
+
+    # Add expected environment variables for bind path and partition if set
+    if data_bind_path is not None:
+        expected_sbatch_env["APPTAINER_BINDPATH"] = f'"{data_bind_path}"'
+    if conversion_partition is not None:
+        expected_sbatch_env["CONVERSION_PARTITION"] = f'"{conversion_partition}"'
+
+    expected_conversion_cmd = 'sbatch --job-name=conversion --export=ALL,CONFIG_PATH="$PWD/$CONFIG_FILE" --array=1-$N "$SCRIPT_PATH/convert_job_array.sh"'
     expected_commands = [
-        f"find \"{expected_data_path}/data/in\" -name \"*.{source_format}\" | awk '{{print NR, $0}}' > \"{expected_config_file}\"",
-        f"N=$(wc -l < \"{expected_config_file}\")",
-        f"echo \"Number of .{source_format} files: $N\"",
-        expected_conversion_cmd
+        f'find "{expected_data_path}/data/in" -name "*.{source_format}" | awk \'{{print NR, $0}}\' > "{expected_config_file}"',
+        f'N=$(wc -l < "{expected_config_file}")',
+        f'echo "Number of .{source_format} files: $N"',
+        expected_conversion_cmd,
     ]
 
     # Mocking the run_commands method to avoid actual execution
@@ -361,7 +414,8 @@ def test_run_conversion_workflow_job_versioned(mock_result, mock_run_commands, s
 
     # WHEN
     slurm_job = slurm_client.run_conversion_workflow_job(
-        folder_name, source_format, target_format)
+        folder_name, source_format, target_format
+    )
 
     # THEN
     assert slurm_job is not None
@@ -373,7 +427,6 @@ def test_run_conversion_workflow_job_versioned(mock_result, mock_run_commands, s
     assert slurm_job.job_id == -1
     assert slurm_job.submit_result.ok
     assert slurm_job.job_state is None
-
 
 def test_pull_descriptor_from_github(slurm_client):
     # GIVEN

--- a/tests/unit/test_slurm_client.py
+++ b/tests/unit/test_slurm_client.py
@@ -1301,8 +1301,10 @@ def test_from_config(mock_ConfigParser,
         enable_job_accounting=True,  # expected enable_job_accounting value
         enable_job_progress=True,  # expected enable_job_progress value
         enable_workflow_analytics=True,  # expected enable_workflow_analytics value
-        sqlalchemy_url='sqlite:///test.db',  # expected sqlalchemy_url value
-        config_only=config_only
+        sqlalchemy_url="sqlite:///test.db",  # expected sqlalchemy_url value
+        config_only=config_only,
+        slurm_data_bind_path=mv,
+        slurm_conversion_partition=mv,
     )
 
 


### PR DESCRIPTION
1. **Added `slurm_data_bind_path` parameter**
   - Enables custom bind paths for Singularity/Apptainer containers
   - Allows proper access to storage locations outside default mounts in container

2. **Added `slurm_conversion_partition` parameter**
   - Enables specifying a dedicated Slurm partition for data conversion jobs
   - Allows resource allocation for conversion tasks when required
